### PR TITLE
Don't redefine static_assert, fixes compilation error

### DIFF
--- a/tools/mkfs.c
+++ b/tools/mkfs.c
@@ -11,7 +11,9 @@
 #include "../include/stat.h"
 #include "../include/param.h"
 
-#define static_assert(a, b) do { switch (0) case 0: case (a): ; } while (0)
+#ifndef static_assert
+# define static_assert(a, b) do { switch (0) case 0: case (a): ; } while (0)
+#endif // static_assert
 
 int nblocks = 985;
 int nlog = LOGSIZE;


### PR DESCRIPTION
Got compilation error while compiling `tools/mkfs.c`:
```sh
...
gcc -Werror -Wall -o out/mkfs tools/mkfs.c
tools/mkfs.c:14:0: error: "static_assert" redefined [-Werror]
 #define static_assert(a, b) do { switch (0) case 0: case (a): ; } while (0)
 ^
In file included from tools/mkfs.c:6:0:
/usr/include/assert.h:120:0: note: this is the location of the previous definition
 # define static_assert _Static_assert
```

The fix is trivial, just checks for an existing `static_assert()`.